### PR TITLE
Support alt k8s login and transit paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "description": "A PHP client library for 'Vault by HashiCorp'",
     "require": {
         "ext-json": "*",
-        "guzzlehttp/psr7": "^1.6",
+        "guzzlehttp/psr7": "^2.4.4",
         "php": "^5.6 || ^7.0 || ^8.0",
         "php-http/httplug": ">=1.1.0"
     },

--- a/src/VaultPHP/Authentication/Provider/Kubernetes.php
+++ b/src/VaultPHP/Authentication/Provider/Kubernetes.php
@@ -22,17 +22,19 @@ class Kubernetes extends AbstractAuthenticationProvider
     /** @var string */
     private $jwt;
     /** @var string  */
-    private $endpoint = '/v1/auth/kubernetes/login';
+    private $endpoint;
 
     /**
      * Kubernetes constructor.
      * @param string $role
      * @param string $jwt
+     * @param string $authPath - defaults to '/auth/kubernetes'
      */
-    public function __construct($role, $jwt)
+    public function __construct($role, $jwt, $authPath = '/auth/kubernetes')
     {
         $this->role = $role;
         $this->jwt = $jwt;
+        $this->endpoint = '/v1' . $authPath . '/login';
     }
 
     /**

--- a/src/VaultPHP/Authentication/Provider/Kubernetes.php
+++ b/src/VaultPHP/Authentication/Provider/Kubernetes.php
@@ -30,11 +30,11 @@ class Kubernetes extends AbstractAuthenticationProvider
      * @param string $jwt
      * @param string $authPath - defaults to '/auth/kubernetes'
      */
-    public function __construct($role, $jwt, $authPath = '/auth/kubernetes')
+    public function __construct($role, $jwt, $authPath = 'auth/kubernetes')
     {
         $this->role = $role;
         $this->jwt = $jwt;
-        $this->endpoint = '/v1' . $authPath . '/login';
+        $this->endpoint = '/v1/' . $authPath . '/login';
     }
 
     /**

--- a/src/VaultPHP/SecretEngines/Engines/Transit/Transit.php
+++ b/src/VaultPHP/SecretEngines/Engines/Transit/Transit.php
@@ -29,6 +29,13 @@ use VaultPHP\SecretEngines\Engines\Transit\Response\UpdateKeyConfigResponse;
  */
 final class Transit extends AbstractSecretEngine
 {
+    private string $APIPath = 'transit';
+
+    public function setAPIPath(string $path)
+    {
+        $this->APIPath = $path;
+    }
+
     /**
      * @param CreateKeyRequest $createKeyRequest
      * @return CreateKeyResponse
@@ -41,7 +48,7 @@ final class Transit extends AbstractSecretEngine
         /** @var CreateKeyResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/keys/%s', urlencode($createKeyRequest->getName())),
+            sprintf('/v1/%s/keys/%s', $this->APIPath, urlencode($createKeyRequest->getName())),
             CreateKeyResponse::class,
             $createKeyRequest
         );
@@ -59,7 +66,7 @@ final class Transit extends AbstractSecretEngine
         /** @var EncryptDataResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/encrypt/%s', urlencode($encryptDataRequest->getName())),
+            sprintf('/v1/%s/encrypt/%s', $this->APIPath, urlencode($encryptDataRequest->getName())),
             EncryptDataResponse::class,
             $encryptDataRequest
         );
@@ -77,7 +84,7 @@ final class Transit extends AbstractSecretEngine
         /** @var BulkEndpointResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/encrypt/%s', urlencode($encryptDataBulkRequest->getName())),
+            sprintf('/v1/%s/encrypt/%s', $this->APIPath, urlencode($encryptDataBulkRequest->getName())),
             EncryptDataResponse::class,
             $encryptDataBulkRequest
         );
@@ -95,7 +102,7 @@ final class Transit extends AbstractSecretEngine
         /** @var DecryptDataResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/decrypt/%s', urlencode($decryptDataRequest->getName())),
+            sprintf('/v1/%s/decrypt/%s', $this->APIPath, urlencode($decryptDataRequest->getName())),
             DecryptDataResponse::class,
             $decryptDataRequest
         );
@@ -115,7 +122,7 @@ final class Transit extends AbstractSecretEngine
         /** @var BulkEndpointResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/decrypt/%s', urlencode($decryptDataBulkRequest->getName())),
+            sprintf('/v1/%s/decrypt/%s', $this->APIPath, urlencode($decryptDataBulkRequest->getName())),
             DecryptDataResponse::class,
             $decryptDataBulkRequest
         );
@@ -132,7 +139,7 @@ final class Transit extends AbstractSecretEngine
         /** @var ListKeysResponse */
         return $this->vaultClient->sendApiRequest(
             'LIST',
-            '/v1/transit/keys',
+            sprintf('/v1/%s/keys', $this->APIPath,),
             ListKeysResponse::class,
             []
         );
@@ -150,7 +157,7 @@ final class Transit extends AbstractSecretEngine
         /** @var EndpointResponse */
         return $this->vaultClient->sendApiRequest(
             'DELETE',
-            sprintf('/v1/transit/keys/%s', urlencode($name)),
+            sprintf('/v1/%s/keys/%s', $this->APIPath, urlencode($name)),
             DeleteKeyResponse::class,
             []
         );
@@ -168,7 +175,7 @@ final class Transit extends AbstractSecretEngine
         /** @var UpdateKeyConfigResponse */
         return $this->vaultClient->sendApiRequest(
             'POST',
-            sprintf('/v1/transit/keys/%s/config', urlencode($updateKeyConfigRequest->getName())),
+            sprintf('/v1/%s/keys/%s/config', $this->APIPath, urlencode($updateKeyConfigRequest->getName())),
             UpdateKeyConfigResponse::class,
             $updateKeyConfigRequest
         );


### PR DESCRIPTION
As the library exists, one cannot use the k8s auth code if the k8s auth endpoint is at a custom path.  Same story for the transit code.  This PR adds the ability to specify the path for each of these Vault modules.  The new abilities were added in a way that should not cause any backward compatibility issues for existing users.

I've also bumped guzzlehttp/psr7 version since it was old and causing issues when trying to import the library through composer on our existing repo with other guzzlehttp uses. 