### PR TITLE
fix deprecation (>=8.2) ${var} => {$var} which is causing deprecation messages

### DIFF
--- a/src/VaultPHP/Response/MetaData.php
+++ b/src/VaultPHP/Response/MetaData.php
@@ -129,7 +129,7 @@ class MetaData implements MetaDataInterface
         foreach ($this->getErrors() as $apiError) {
             /** @var string $errorMessage */
             foreach ($error as $errorMessage) {
-                if (preg_match("#${errorMessage}#i", $apiError)) {
+                if (preg_match("#{$errorMessage}#i", $apiError)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Since PHP 8.2, using ${var} is deprecated and we should use {$var} instead. This fix this removing deprecation messages.