### PR TITLE
Relax guzzlehttp/psr7 version constraint and typehint to psr/http-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "guzzlehttp/psr7": "^2.6",
         "php": "^7.2.5 || ^8.0",
-        "php-http/httplug": "^2.4"
+        "psr/http-client": "^1.0"
     },
     "suggest": {
         "php-http/curl-client": "CURL Client Adapter",

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "description": "A PHP client library for 'Vault by HashiCorp'",
     "require": {
         "ext-json": "*",
-        "guzzlehttp/psr7": "2.6.2",
+        "guzzlehttp/psr7": "^2.6",
         "php": "^7.2.5 || ^8.0",
-        "php-http/httplug": "2.4.0"
+        "php-http/httplug": "^2.4"
     },
     "suggest": {
         "php-http/curl-client": "CURL Client Adapter",

--- a/tests/VaultPHP/Exceptions/ExceptionsTest.php
+++ b/tests/VaultPHP/Exceptions/ExceptionsTest.php
@@ -3,8 +3,8 @@
 namespace Test\VaultPHP\Response;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Test\VaultPHP\Mocks\InvalidEndpointResponseMock;
@@ -37,7 +37,7 @@ final class ExceptionsTest extends TestCase
         $this->expectExceptionMessage('can\'t parse provided apiHost - malformed uri');
 
         $auth = new Token('fooToken');
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
 
         $client = new VaultClient($httpClient, $auth, "imInvalidHost");
         $client->sendApiRequest('LOL', '/i/should/be/preserved', EndpointResponse::class, ['dontReplaceMe']);
@@ -46,7 +46,7 @@ final class ExceptionsTest extends TestCase
     public function testAuthenticateWillThrowWhenNoTokenIsReturned() {
         $this->expectException(VaultAuthenticationException::class);
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -61,7 +61,7 @@ final class ExceptionsTest extends TestCase
     public function testWillThrowWhenAPIReturns403() {
         $this->expectException(VaultAuthenticationException::class);
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $auth = $this->createMock(AuthenticationProviderInterface::class);
         $auth
             ->expects($this->once())
@@ -76,7 +76,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultHttpException::class);
         $this->expectExceptionMessage('foobarMessage');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -97,7 +97,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Return Class declaration lacks static::fromResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -118,7 +118,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Return Class declaration lacks static::fromBulkResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -139,7 +139,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Result from "fromResponse/fromBulkResponse" isn\'t an instance of EndpointResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')

--- a/tests/VaultPHP/SecretEngines/AbstractSecretEngineTestCase.php
+++ b/tests/VaultPHP/SecretEngines/AbstractSecretEngineTestCase.php
@@ -3,8 +3,8 @@
 namespace Test\VaultPHP\SecretEngines;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use VaultPHP\Authentication\Provider\Token;
 use VaultPHP\VaultClient;
@@ -17,7 +17,7 @@ abstract class AbstractSecretEngineTestCase extends TestCase
 {
     protected function createApiClient($expectedMethod, $expectedPath, $expectedData, $responseData, $responseStatus = 200)
     {
-        $httpMock = $this->createMock(HttpClient::class);
+        $httpMock = $this->createMock(ClientInterface::class);
         $httpMock
             ->expects($this->once())
             ->method('sendRequest')

--- a/tests/VaultPHP/TestHelperTrait.php
+++ b/tests/VaultPHP/TestHelperTrait.php
@@ -3,7 +3,7 @@
 namespace Test\VaultPHP;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use VaultPHP\Authentication\Provider\Token;
 use VaultPHP\Response\EndpointResponse;
 use VaultPHP\VaultClient;
@@ -29,7 +29,7 @@ trait TestHelperTrait {
         $response = new Response($responseStatus, $responseHeader, $responseBody);
         $auth = new Token('fooToken');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
 
         $httpClient
             ->expects($this->once())

--- a/tests/VaultPHP/VaultClientTest.php
+++ b/tests/VaultPHP/VaultClientTest.php
@@ -3,8 +3,8 @@
 namespace Test\VaultPHP;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Test\VaultPHP\Mocks\EndpointResponseMock;
 use VaultPHP\Authentication\AuthenticationProviderInterface;
@@ -23,7 +23,7 @@ final class VaultClientTest extends TestCase
     public function testAuthProviderGetsClientInjected()
     {
         $auth = new Token('foo');
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $client = new VaultClient($httpClient, $auth, TEST_VAULT_ENDPOINT);
 
         $this->assertSame($client, $auth->getVaultClient());
@@ -32,7 +32,7 @@ final class VaultClientTest extends TestCase
     public function testRequestWillExtendedWithDefaultVars() {
         $auth = new Token('fooToken');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -61,7 +61,7 @@ final class VaultClientTest extends TestCase
     public function testSendRequest() {
         $response = new Response();
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')


### PR DESCRIPTION
The exact version constraint of the psr7 lib caused some issues on our end. Relaxing a bit seems fine I guess. 

Also removed the direct dependency to httplug to keep things simpler. Was only used in tests anyway. 