### PR TITLE
fix: make port optional in vault api host

### DIFF
--- a/src/VaultPHP/VaultClient.php
+++ b/src/VaultPHP/VaultClient.php
@@ -233,15 +233,18 @@ class VaultClient
         $token = $this->authenticationMetaData ? $this->authenticationMetaData->getClientToken() : '';
         $hostEndpoint = parse_url($this->apiHost);
 
-        if (!is_array($hostEndpoint) || !isset($hostEndpoint['scheme']) || !isset($hostEndpoint['host']) || !isset($hostEndpoint['port'])) {
+        if (!is_array($hostEndpoint) || !isset($hostEndpoint['scheme']) || !isset($hostEndpoint['host'])) {
             throw new VaultException('can\'t parse provided apiHost - malformed uri');
         }
 
         $uriWithHost = $request
             ->getUri()
             ->withScheme($hostEndpoint['scheme'])
-            ->withHost($hostEndpoint['host'])
-            ->withPort($hostEndpoint['port']);
+            ->withHost($hostEndpoint['host']);
+
+        if (isset($hostEndpoint['port'])) {
+            $uriWithHost = $uriWithHost->withPort($hostEndpoint['port']);
+        }
 
         return $request
             ->withUri($uriWithHost)


### PR DESCRIPTION
I'm running Vault on a subdomain using the default port (443). But I'm still required to provide the port in the api host.

```text
https://vault.example.com:443 => http://vault.example.com
```

This PR removes that requirement.